### PR TITLE
Add InnoDB declaration for image_locations table

### DIFF
--- a/glance/db/sqlalchemy/migrate_repo/versions/018_add_image_locations_table.py
+++ b/glance/db/sqlalchemy/migrate_repo/versions/018_add_image_locations_table.py
@@ -50,6 +50,7 @@ def upgrade(migrate_engine):
                           nullable=False,
                           default=False,
                           index=True),
+        mysql_engine='InnoDB'
     )
 
     schema.create_tables([image_locations_table])


### PR DESCRIPTION
Hello, there is a bug for this table. When a MySQL has as default table a different engine than InnoDB, (e.g. ndbcluster) glance-mananger db_sync is failing.
