### PR TITLE
missing warlock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,6 @@ iso8601>=0.1.11 # MIT
 os-win>=3.0.0 # Apache-2.0
 
 castellan>=0.17.0 # Apache-2.0
+
+# glance
+warlock>=1.3.3 # Apache-2.0


### PR DESCRIPTION
After a `python3 setup.py install`on CentOS 8, I ran `glance`. It repsonds `No module named 'warlock'`. After `pip3 install warlock`, glance works well. 
[WARN] I don't know the minimum version needed for. I just know that under 1.3.3 it's working well.