### PR TITLE
Use psycopg2-binary for test-requirements instead of Use psycopg2

### DIFF
--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -84,7 +84,7 @@ pika-pool==0.1.3
 pika==0.10.0
 prettytable==0.7.1
 psutil==3.2.2
-psycopg2==2.8.4
+psycopg2-binary==2.8.4
 pycadf==2.7.0
 pycparser==2.18
 Pygments==2.2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,7 +25,7 @@ Pygments>=2.2.0  # BSD license
 
 # Optional packages that should be installed when testing
 PyMySQL>=0.7.6 # MIT License
-psycopg2>=2.8.4 # LGPL/ZPL
+psycopg2-binary==2.8.4 # LGPL/ZPL
 pysendfile>=2.0.0;sys_platform!='win32' # MIT
 xattr>=0.9.2;sys_platform!='win32' # MIT
 python-swiftclient>=3.2.0 # Apache-2.0


### PR DESCRIPTION
To move binary to assist in simple deployment of a binary artifact during CI, which simplifies the ability to run those tests.